### PR TITLE
Implement API integration to fetch learning content from Acorn External Catalogue

### DIFF
--- a/app/lib/utils/fetchData.ts
+++ b/app/lib/utils/fetchData.ts
@@ -1,0 +1,32 @@
+const BASE_URL = process.env.ACORN_API_BASE_URL!;
+const BEARER_TOKEN = process.env.ACORN_API_BEARER_TOKEN!;
+
+export const fetchData = async <T>(requestUrl: string): Promise<T> => {
+  const fullUrl = `${BASE_URL}${requestUrl}`;
+
+  const requestOptions: RequestInit = {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${BEARER_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    next: { revalidate: 60 } 
+  };
+
+  try {
+    const response = await fetch(fullUrl, requestOptions);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch. Status: ${response.status}, ${response.statusText}`
+      );
+    }
+
+    return response.json();
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+    throw new Error('An unknown error occurred during fetch');
+  }
+};

--- a/app/services/getCatalogue.ts
+++ b/app/services/getCatalogue.ts
@@ -1,0 +1,7 @@
+import { fetchData } from '@/app/lib/utils/fetchData';
+
+
+export const getCatalogue = async () => {
+  const path = '/local/acorn_coursemanagement/index.php/api/1.1/external_catalogue/188?perPage=16';
+  return await fetchData(path);
+};


### PR DESCRIPTION
The PR will:

- [x] Integrate the Acorn External Catalogue API to fetch learning content using the provided endpoint.

- [x] Add a reusable fetchData utility that handles authenticated API requests with the Bearer token.

- [x] Implement the getCatalogue service function to retrieve and type the catalogue data.

- [x] Ensure proper error handling and maintainability for future API integrations.